### PR TITLE
Store the list of files of a sample along with the folder

### DIFF
--- a/scripts/SAMADhi.sql
+++ b/scripts/SAMADhi.sql
@@ -7,6 +7,7 @@ DROP TABLE IF EXISTS result;
 DROP TABLE IF EXISTS sample;
 DROP TABLE IF EXISTS dataset;
 DROP TABLE IF EXISTS users;
+DROP TABLE IF EXISTS file;
 
 CREATE TABLE  users
 (
@@ -48,6 +49,7 @@ sampletype varchar(255) NOT NULL,
 nevents_processed int,
 nevents int,
 normalization float NOT NULL DEFAULT 1.0, 
+event_weight_sum float NOT NULL DEFAULT 1.0,
 luminosity float,
 code_version varchar(255),
 user_comment text,
@@ -144,3 +146,14 @@ FOREIGN KEY (event_id) REFERENCES event(event_id),
 FOREIGN KEY (madweight_run) REFERENCES madweightrun(mwrun_id)
 );
 
+CREATE TABLE file
+(
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    sample_id int NOT NULL,
+    lfn varchar(500) NOT NULL,
+    pfn varchar(500) NOT NULL,
+    event_weight_sum float,
+    nevents BIGINT,
+    PRIMARY KEY (id),
+    FOREIGN KEY (sample_id) REFERENCES sample(sample_id) ON DELETE CASCADE
+);

--- a/scripts/SAMADhi.sql
+++ b/scripts/SAMADhi.sql
@@ -17,7 +17,7 @@ password VARCHAR( 32 ) NOT NULL ,
 role ENUM('READ ONLY','NO ACCESS','EDIT','DELETE','USER','ADMIN') DEFAULT 'READ ONLY',
 PRIMARY KEY (userID) ,
 UNIQUE (userName)
-);
+) ENGINE = INNODB;
 
 INSERT INTO 'users' (`userName`,`password`,`role`)
 VALUES ('adminUser','050f02a6a1221639d03d1ad935ff7fbf','ADMIN');
@@ -38,7 +38,7 @@ creation_time datetime,
 user_comment text,
 PRIMARY KEY (dataset_id),
 KEY idx_name (name)
-);
+) ENGINE = INNODB;
 
 CREATE TABLE sample
 (
@@ -61,7 +61,7 @@ PRIMARY KEY (sample_id),
 KEY idx_name (name),
 FOREIGN KEY (source_dataset_id) REFERENCES dataset(dataset_id),
 FOREIGN KEY (source_sample_id) REFERENCES sample(sample_id)
-);
+) ENGINE = INNODB;
 
 CREATE TABLE result
 (
@@ -72,7 +72,7 @@ author tinytext,
 creation_time timestamp,
 PRIMARY KEY (result_id),
 KEY idx_path (path)
-);
+) ENGINE = INNODB;
 
 CREATE TABLE sampleresult
 (
@@ -81,7 +81,7 @@ result_id int NOT NULL,
 CONSTRAINT SR_ID PRIMARY KEY (sample_id,result_id),
 FOREIGN KEY (sample_id) REFERENCES sample(sample_id),
 FOREIGN KEY (result_id) REFERENCES result(result_id)
-);
+) ENGINE = INNODB;
 
 CREATE TABLE event
 (
@@ -91,7 +91,7 @@ run_number int NOT NULL,
 dataset_id int NOT NULL,
 PRIMARY KEY (event_id),
 FOREIGN KEY (dataset_id) REFERENCES dataset(dataset_id)
-);
+) ENGINE = INNODB;
 
 CREATE TABLE madweight
 (
@@ -116,7 +116,7 @@ transfer_fctVersion varchar(255) NOT NULL,
 transfer_function text NOT NULL,
 PRIMARY KEY (process_id),
 KEY idx_name (name)
-);
+) ENGINE = INNODB;
 
 CREATE TABLE madweightrun
 (
@@ -131,7 +131,7 @@ PRIMARY KEY (mwrun_id),
 UNIQUE INDEX (madweight_process,lhco_sample_id,systematics,version),
 FOREIGN KEY (madweight_process) REFERENCES madweight(process_id),
 FOREIGN KEY (lhco_sample_id) REFERENCES sample(sample_id)
-);
+) ENGINE = INNODB;
 
 CREATE TABLE weight
 (
@@ -144,7 +144,7 @@ PRIMARY KEY (weight_id),
 UNIQUE INDEX (event_id,madweight_run),
 FOREIGN KEY (event_id) REFERENCES event(event_id),
 FOREIGN KEY (madweight_run) REFERENCES madweightrun(mwrun_id)
-);
+) ENGINE = INNODB;
 
 CREATE TABLE file
 (
@@ -156,4 +156,4 @@ CREATE TABLE file
     nevents BIGINT,
     PRIMARY KEY (id),
     FOREIGN KEY (sample_id) REFERENCES sample(sample_id) ON DELETE CASCADE
-);
+) ENGINE = INNODB;

--- a/scripts/v1_to_v2_upgrade.sql
+++ b/scripts/v1_to_v2_upgrade.sql
@@ -1,0 +1,31 @@
+-- Upgrade SAMADhi from v1 to v2
+-- Add a `file` table
+-- Add a `event_weight_sum` column to the sample table
+-- Change default engine from MyISAM to InnoDB
+
+-- Change engine
+ALTER TABLE weight ENGINE=InnoDB;
+ALTER TABLE madweightrun ENGINE=InnoDB;
+ALTER TABLE madweight ENGINE=InnoDB;
+ALTER TABLE event ENGINE=InnoDB;
+ALTER TABLE sampleresult ENGINE=InnoDB;
+ALTER TABLE result ENGINE=InnoDB;
+ALTER TABLE sample ENGINE=InnoDB;
+ALTER TABLE dataset ENGINE=InnoDB;
+ALTER TABLE users ENGINE=InnoDB;
+
+-- Alter sample table
+ALTER TABLE sample ADD event_weight_sum float NOT NULL DEFAULT 1.0;
+
+-- Create `file` table
+CREATE TABLE file
+(
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    sample_id int NOT NULL,
+    lfn varchar(500) NOT NULL,
+    pfn varchar(500) NOT NULL,
+    event_weight_sum float,
+    nevents BIGINT,
+    PRIMARY KEY (id),
+    FOREIGN KEY (sample_id) REFERENCES sample(sample_id) ON DELETE CASCADE
+) ENGINE = INNODB;


### PR DESCRIPTION
This PR change the DB layout to store the list of files of a dataset:

 - A new column ``event_weight_sum`` is added to the ``sample`` table to avoid any confusions in a distant future, when every body would have forget that ``normalization`` is instead the sum of event weight.
 - A new table ``file`` is added, with a foreign key to the ``sample``.``sample_id`` column and a ``on cascade drop`` relationship.
 - Default engine is now ``InnoDB`` instead of ``MyISAM`` in order to support transactions.
 - A migration script is provided which will update the current layout to the new one. It was successfully tested on a copy of the current database.

This was tested on https://github.com/cp3-llbb/GridIn/pull/27  and work as expected.